### PR TITLE
Update Edinburgh config for MAUS parsing

### DIFF
--- a/Common/common.py
+++ b/Common/common.py
@@ -122,6 +122,8 @@ def loading(config, corpus_dir, textgrid_format):
             parser = pgio.inspect_partitur(corpus_dir)
         elif textgrid_format == "timit":
             parser = pgio.inspect_timit(corpus_dir)
+        elif textgrid_format in ["W", "maus"]:
+            parser = pgio.inspect_maus(corpus_dir)
         else:
             parser = pgio.inspect_mfa(corpus_dir)
         parser.call_back = call_back

--- a/spade-Edinburgh/spade-Edinburgh.yaml
+++ b/spade-Edinburgh/spade-Edinburgh.yaml
@@ -1,5 +1,5 @@
 corpus_directory: "/projects/spade/repo/git/spade-Edinburgh/"
-input_format: "MFA"
+input_format: "W"
 dialect_code: "edi"
 unisyn_spade_directory: "/data/mmcauliffe/dev/unisyn_spade"
 speaker_enrichment_file: "/projects/spade/repo/git/spade-Edinburgh/corpus-data/enrichment/speaker_info.csv"
@@ -8,6 +8,6 @@ vowel_inventory: ["A:", "i:", "I", "{", "V", "Q", "O:", "U", "u:", "@", "eI", "a
 extra_syllabic_segments: []
 stressed_vowels: []
 sibilant_segments: [s, z, S, Z]
-pauses: '^<p:>$'
+pauses: '^<SIL>$'
 
 #Change MFA to correct input format (MAUS-aligned)


### PR DESCRIPTION
This makes the Edinburgh corpus parsable by the MAUS parser and corrects the label for pause words.