### PR TITLE
Update speaker names in YAML

### DIFF
--- a/spade-Doubletalk/spade-Doubletalk.yaml
+++ b/spade-Doubletalk/spade-Doubletalk.yaml
@@ -3,7 +3,7 @@ input_format: "MFA"
 dialect_code: "edi"
 unisyn_spade_directory: "/data/mmcauliffe/dev/unisyn_spade"
 speaker_enrichment_file: "/projects/spade/repo/git/spade-Doubletalk/corpus-data/enrichment/speaker_info.csv"
-speakers: [R0020_cs5, R0020_cs6, R0033_cs5, R0033_cs6, R0034_cs5, R0034_cs6, R0035_cs5, R0035_cs6, R0036_cs5, R0036_cs6, R0039_cs5, R0039_cs6]
+speakers: ['R0020cs5', 'R0020cs6', 'R0033cs5', 'R0033cs6', 'R0034cs5', 'R0034cs6', 'R0035cs5', 'R0035cs6', 'R0036cs5', 'R0036cs6', 'R0039cs5', 'R0039cs6']
 vowel_inventory: ["ER0", "IH2", "EH1", "AE0", "UH1", "AY2", "AW2", "UW1", "OY2", "OY1", "AO0", "AH2", "ER1", "AW1", "OW0", "IY1", "IY2", "UW0", "AA1", "EY0", "AE1", "AA0", "OW1", "AW0", "AO1", "AO2", "IH0", "ER2", "UW2", "IY0", "AE2", "AH0", "AH1", "UH2", "EH2", "UH0", "EY1", "AY0", "AY1", "EH0", "EY2", "AA2", "OW2", "IH1"]
 stressed_vowels: ["EH1", "UH1", "UW1", "OY1", "ER1", "AW1", "IY1", "AA1", "AE1", "OW1",  "AO1", "AH1", "EY1", "AY1", "IH1"]
 extra_syllabic_segments: []


### PR DESCRIPTION
This updates the names of the speakers to match the corrected naming scheme in the corpus repository.