### PR TITLE
Add database access check

### DIFF
--- a/Common/common.py
+++ b/Common/common.py
@@ -13,6 +13,7 @@ import polyglotdb.io as pgio
 from polyglotdb import CorpusContext
 from polyglotdb.io.enrichment import enrich_speakers_from_csv, enrich_lexicon_from_csv
 from polyglotdb.acoustics.formants.refined import analyze_formant_points_refinement
+from polyglotdb.client.client import PGDBClient, ClientError
 
 base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -441,6 +442,13 @@ def get_size_of_corpus(config):
         results = q.all()
     return results[0]['result']
 
+def check_database(corpus_name, token = load_token(), port = 8080):
+    host = 'http://localhost:{}'.format(port)
+    client = PGDBClient(host, token)
+    try:
+        client.start_database(corpus_name)
+    except Exception as e:
+        print("Database problem: {}".format(e))
 
 def basic_queries(config):
     from polyglotdb.query.base.func import Sum

--- a/duration.py
+++ b/duration.py
@@ -122,6 +122,10 @@ if __name__ == '__main__':
         sys.exit(1)
     corpus_conf = common.load_config(corpus_name)
     print('Processing...')
+
+    # sanity check database access
+    common.check_database(corpus_name)
+
     with ensure_local_database_running(corpus_name, port=8080, token=common.load_token()) as params:
         config = CorpusConfig(corpus_name, **params)
         config.formant_source = 'praat'


### PR DESCRIPTION
This checks whether a database can be accessed in its current state, and prints the error if not. This has been written as a try/except as it would throw an error if the database didn't exist - this would be a problem as deleting a database is a common step in getting a malfunctioning database to work.

I added this to `common.py` so the other analysis functions can make use of this.